### PR TITLE
added tests to POST /crops/{crop}/studies/{studyId}/datasets/{dataset…

### DIFF
--- a/BMSAPI.postman_collection.json
+++ b/BMSAPI.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "96efe3e8-692b-428b-9943-d4021f9bae9b",
+		"_postman_id": "5ba84076-0b1d-4570-8075-5b1e6e760aad",
 		"name": "BMSAPI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -5152,6 +5152,568 @@
 									]
 								},
 								"description": "PUT /crops/{crop}/studies/{studyId}/datasets/{datasetId}/variables"
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "POST /crops/{crop}/studies/{studyId}/datasets/{datasetId}/observationUnits/{observationUnitId}",
+					"item": [
+						{
+							"name": "Verify if user can add accepted observation",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1abccc7b-cf55-4065-b182-061588ec1222",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"var jsonData = pm.response.json();",
+											"pm.test(\"Check returned variableId \", function () {",
+											"    var biomasId = Number(pm.environment.get(\"study_biomass_cvterm_id\"));",
+											"    pm.expect(jsonData.variableId).to.equal(biomasId);",
+											"});",
+											"pm.test(\"Check returned value \", function () {",
+											"    pm.expect(jsonData.value).to.equal(\"5\");",
+											"});",
+											"",
+											"pm.test(\"Check returned categoricalValueId \", function () {",
+											"    pm.expect(jsonData.categoricalValueId).to.equal(null);",
+											"});",
+											"pm.test(\"Check returned status \", function () {",
+											"    pm.expect(jsonData.status).to.equal(null);",
+											"});",
+											"pm.test(\"Check returned observationUnitId \", function () {",
+											"    var observationUnitId = Number(pm.environment.get(\"study_observationUnitId\"));",
+											"    pm.expect(jsonData.observationUnitId).to.equal(observationUnitId);",
+											"});",
+											"pm.test(\"Check returned draftCategoricalValueId \", function () {",
+											"    pm.expect(jsonData.draftCategoricalValueId).to.equal(null);",
+											"});",
+											"pm.test(\"Check returned draftValue \", function () {",
+											"    pm.expect(jsonData.draftValue).to.equal(null);",
+											"});",
+											"pm.test(\"Check returned draftMode \", function () {",
+											"    pm.expect(jsonData.draftMode).to.equal(false);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "X-Auth-Token",
+										"value": "{{masterToken}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"categoricalValueId\": null,\r\n  \"variableId\": \"{{study_biomass_cvterm_id}}\",\r\n  \"value\": \"5\",\r\n  \"observationUnitId\": \"{{study_observationUnitId}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{study_subobs_datasetId}}/observationUnits/{{study_observationUnitId}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{study_subobs_datasetId}}",
+										"observationUnits",
+										"{{study_observationUnitId}}"
+									]
+								},
+								"description": "POST /crops/{crop}/studies/{studyId}/datasets/{datasetId}/observationUnits/{observationUnitId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered non-existing studyId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1abccc7b-cf55-4065-b182-061588ec1222",
+										"exec": [
+											"pm.test(\"Status code is 404\", function () {",
+											"    pm.response.to.have.status(404);",
+											"});",
+											"pm.test(\"Verify error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors[0].message).to.eql(\"Study does not exist\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"categoricalValueId\": null,\r\n  \"variableId\": \"{{study_biomass_cvterm_id}}\",\r\n  \"value\": \"5\",\r\n  \"observationUnitId\": \"{{study_observationUnitId}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{non_existing_study_id}}/datasets/{{study_subobs_datasetId}}/observationUnits/{{study_observationUnitId}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{non_existing_study_id}}",
+										"datasets",
+										"{{study_subobs_datasetId}}",
+										"observationUnits",
+										"{{study_observationUnitId}}"
+									]
+								},
+								"description": "POST /crops/{crop}/studies/{studyId}/datasets/{datasetId}/observationUnits/{observationUnitId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered non-existing datasetId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1abccc7b-cf55-4065-b182-061588ec1222",
+										"exec": [
+											"pm.test(\"Status code is 404\", function () {",
+											"    pm.response.to.have.status(404);",
+											"});",
+											"pm.test(\"Verify error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors[0].message).to.eql(\"Dataset does not exist\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"categoricalValueId\": null,\r\n  \"variableId\": \"{{study_biomass_cvterm_id}}\",\r\n  \"value\": \"5\",\r\n  \"observationUnitId\": \"{{study_observationUnitId}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{non_existing_dataset_id}}/observationUnits/{{study_observationUnitId}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{non_existing_dataset_id}}",
+										"observationUnits",
+										"{{study_observationUnitId}}"
+									]
+								},
+								"description": "POST /crops/{crop}/studies/{studyId}/datasets/{datasetId}/observationUnits/{observationUnitId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered string input to studyId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1abccc7b-cf55-4065-b182-061588ec1222",
+										"exec": [
+											"pm.test(\"Status code is 500\", function () {",
+											"    pm.response.to.have.status(500);",
+											"});",
+											"pm.test(\"Verify error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors[0].message).to.eql(\"For input string: \\\"asd\\\"\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"categoricalValueId\": null,\r\n  \"variableId\": \"{{study_biomass_cvterm_id}}\",\r\n  \"value\": \"5\",\r\n  \"observationUnitId\": \"{{study_observationUnitId}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{string_input}}/datasets/{{study_observationUnitId}}/observationUnits/{{study_observationUnitId}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{string_input}}",
+										"datasets",
+										"{{study_observationUnitId}}",
+										"observationUnits",
+										"{{study_observationUnitId}}"
+									]
+								},
+								"description": "POST /crops/{crop}/studies/{studyId}/datasets/{datasetId}/observationUnits/{observationUnitId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered string input to datasetId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1abccc7b-cf55-4065-b182-061588ec1222",
+										"exec": [
+											"pm.test(\"Status code is 500\", function () {",
+											"    pm.response.to.have.status(500);",
+											"});",
+											"pm.test(\"Verify error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors[0].message).to.eql(\"For input string: \\\"asd\\\"\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"categoricalValueId\": null,\r\n  \"variableId\": \"{{study_biomass_cvterm_id}}\",\r\n  \"value\": \"5\",\r\n  \"observationUnitId\": \"{{study_observationUnitId}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{string_input}}/observationUnits/{{study_observationUnitId}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{string_input}}",
+										"observationUnits",
+										"{{study_observationUnitId}}"
+									]
+								},
+								"description": "POST /crops/{crop}/studies/{studyId}/datasets/{datasetId}/observationUnits/{observationUnitId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered string input to observationUnitId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1abccc7b-cf55-4065-b182-061588ec1222",
+										"exec": [
+											"pm.test(\"Status code is 500\", function () {",
+											"    pm.response.to.have.status(500);",
+											"});",
+											"pm.test(\"Verify error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors[0].message).to.eql(\"For input string: \\\"asd\\\"\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"categoricalValueId\": null,\r\n  \"variableId\": \"{{study_biomass_cvterm_id}}\",\r\n  \"value\": \"5\",\r\n  \"observationUnitId\": \"{{study_observationUnitId}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{study_subobs_datasetId}}/observationUnits/{{string_input}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{study_subobs_datasetId}}",
+										"observationUnits",
+										"{{string_input}}"
+									]
+								},
+								"description": "POST /crops/{crop}/studies/{studyId}/datasets/{datasetId}/observationUnits/{observationUnitId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered datasetId that is not a subobs dataset",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1abccc7b-cf55-4065-b182-061588ec1222",
+										"exec": [
+											"pm.test(\"Status code is 501\", function () {",
+											"    pm.response.to.have.status(501);",
+											"});",
+											"pm.test(\"Verify error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors[0].message).to.eql(\"Dataset is not a subobservation dataset.\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "X-Auth-Token",
+										"value": "{{masterToken}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"categoricalValueId\": null,\r\n  \"variableId\": \"{{study_biomass_cvterm_id}}\",\r\n  \"value\": \"5\",\r\n  \"observationUnitId\": \"{{study_observationUnitId}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{study_plot_datasetId}}/observationUnits/{{study_observationUnitId}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{study_plot_datasetId}}",
+										"observationUnits",
+										"{{study_observationUnitId}}"
+									]
+								},
+								"description": "POST /crops/{crop}/studies/{studyId}/datasets/{datasetId}/observationUnits/{observationUnitId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered studyId and subobs datasetId do not belong to each other",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1abccc7b-cf55-4065-b182-061588ec1222",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"pm.test(\"Verify error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors[0].message).to.eql(\"Specified dataset 3017 does not belong to the study 3013\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"categoricalValueId\": null,\r\n  \"variableId\": \"{{study_biomass_cvterm_id}}\",\r\n  \"value\": \"5\",\r\n  \"observationUnitId\": \"{{study_observationUnitId}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{trialStudyId}}/datasets/{{study_subobs_datasetId}}/observationUnits/{{study_observationUnitId}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{trialStudyId}}",
+										"datasets",
+										"{{study_subobs_datasetId}}",
+										"observationUnits",
+										"{{study_observationUnitId}}"
+									]
+								},
+								"description": "POST /crops/{crop}/studies/{studyId}/datasets/{datasetId}/observationUnits/{observationUnitId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered invalid observationUnitId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "1abccc7b-cf55-4065-b182-061588ec1222",
+										"exec": [
+											"pm.test(\"Status code is 404\", function () {",
+											"    pm.response.to.have.status(404);",
+											"});",
+											"pm.test(\"Verify error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors[0].message).to.eql(\"Invalid observation unit id.\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"categoricalValueId\": null,\r\n  \"variableId\": \"{{study_biomass_cvterm_id}}\",\r\n  \"value\": \"5\",\r\n  \"observationUnitId\": \"{{study_observationUnitId}}\"\r\n}"
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{study_subobs_datasetId}}/observationUnits/500",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{study_subobs_datasetId}}",
+										"observationUnits",
+										"500"
+									]
+								},
+								"description": "POST /crops/{crop}/studies/{studyId}/datasets/{datasetId}/observationUnits/{observationUnitId}"
 							},
 							"response": []
 						}

--- a/BMS_Environment.postman_environment.json
+++ b/BMS_Environment.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "f36f0654-5fcc-42c6-84c8-183641a9fe39",
+	"id": "0b05e9c0-df8d-4850-9bd2-ebeb086068d2",
 	"name": "BMS_Environment",
 	"values": [
 		{
@@ -520,9 +520,111 @@
 			"value": "1",
 			"description": "",
 			"enabled": true
+		},
+		{
+			"key": "studyId_for_subobs_generation",
+			"value": "3046",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "plot_datasetId_for_subobs_generation",
+			"value": "3034",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "plant_no_cvtermId",
+			"value": "8206",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "instanceId_for_subobs_generation",
+			"value": "7",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "quadrat_no_cvtermId",
+			"value": "8207",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "date_no_cvtermId",
+			"value": "8205",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "custom_subobs_no_cvtermId",
+			"value": "100018",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "quadrat_subobs_datasetTypeId",
+			"value": "10095",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "time_series_subobs_datasetTypeId",
+			"value": "10096",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "custom_subobs_datasetTypeId",
+			"value": "10097",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "instanceId_for_subobs_generation2",
+			"value": "10",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "variableTypeId_env_detail",
+			"value": "1806",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "variableTypeId_exp_design",
+			"value": "1810",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "variableTypeId_germ_desc",
+			"value": "1804",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "variableTypeId_obs_unit",
+			"value": "1812",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "variableTypeId_selection",
+			"value": "1807",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "study_observationUnitId",
+			"value": "1500",
+			"description": "",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2019-05-28T08:14:38.354Z",
+	"_postman_exported_at": "2019-05-29T07:46:07.674Z",
 	"_postman_exported_using": "Postman/6.7.4"
 }


### PR DESCRIPTION
…Id}/observationUnits/{observationUnitId}

**Call:** POST /crops/{crop}/studies/{studyId}/datasets/{datasetId}/observationUnits/{observationUnitId}
**Test Scenarios:**

1. Verify if user can add accepted observation
2. Verify response code and body when entered non-existing studyId
3. Verify response code and body when entered non-existing datasetId
4. Verify response code and body when entered string input to studyId
5. Verify response code and body when entered string input to datasetId
6. Verify response code and body when entered string input to observationUnitId
7. Verify response code and body when entered datasetId that is not a subobs dataset
8. Verify response code and body when entered studyId and subobs datasetId do not belong to each other
9. Verify response code and body when entered invalid observationUnitId

**Note:** Scenarios for adding draft values to follow.