### PR TITLE
add tests for GET /crops/{crop}/studies/{studyId}/datasets/{datasetId…

### DIFF
--- a/BMSAPI.postman_collection.json
+++ b/BMSAPI.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "5ba84076-0b1d-4570-8075-5b1e6e760aad",
+		"_postman_id": "72404bcc-d7f6-4204-8f04-b4b59d77d3d0",
 		"name": "BMSAPI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -3957,6 +3957,584 @@
 									]
 								},
 								"description": "GET /crops/{crop}/studies/{studyId}/datasets/{datasetId}/observationUnits/table/columns"
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "GET /crops/{crop}/studies/{studyId}/datasets/{datasetId}/variables/{variableTypeId}",
+					"item": [
+						{
+							"name": "Verify response code and body when entered valid inputs and trait variableTypeId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "9ed945ed-1c5e-4a2a-a094-5d265d301385",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Check returned variable id\", function() {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData[0].id).to.equal(18100);",
+											"    pm.expect(jsonData[1].id).to.equal(18000);",
+											"    pm.expect(jsonData[2].id).to.equal(18010);",
+											"});",
+											"",
+											"pm.test(\"Check returned variable names\", function() {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData[0].name).to.equal(\"WeedPressure_number\");",
+											"    pm.expect(jsonData[1].name).to.equal(\"Grain_yield\");",
+											"    pm.expect(jsonData[2].name).to.equal(\"Biomas_yield\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Auth-Token",
+										"value": "{{masterToken}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{study_plot_datasetId}}/variables/{{Trait_cvtermId}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{study_plot_datasetId}}",
+										"variables",
+										"{{Trait_cvtermId}}"
+									]
+								},
+								"description": "GET /crops/{crop}/studies/{studyId}/datasets/{datasetId}/variables/{variableTypeId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered valid inputs and environment detail variableTypeId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "9ed945ed-1c5e-4a2a-a094-5d265d301385",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Check returned variable id\", function() {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData[0].id).to.equal(8170);",
+											"});",
+											"",
+											"pm.test(\"Check returned variable name\", function() {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData[0].name).to.equal(\"TRIAL_INSTANCE\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{study_plot_datasetId}}/variables/{{variableTypeId_env_detail}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{study_plot_datasetId}}",
+										"variables",
+										"{{variableTypeId_env_detail}}"
+									]
+								},
+								"description": "GET /crops/{crop}/studies/{studyId}/datasets/{datasetId}/variables/{variableTypeId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered valid inputs and experimental design variableTypeId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "9ed945ed-1c5e-4a2a-a094-5d265d301385",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Check returned variable id\", function() {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData[0].id).to.equal(8200);",
+											"});",
+											"",
+											"pm.test(\"Check returned variable name\", function() {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData[0].name).to.equal(\"PLOT_NO\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{study_plot_datasetId}}/variables/{{variableTypeId_exp_design}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{study_plot_datasetId}}",
+										"variables",
+										"{{variableTypeId_exp_design}}"
+									]
+								},
+								"description": "GET /crops/{crop}/studies/{studyId}/datasets/{datasetId}/variables/{variableTypeId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered valid inputs and germplasm descriptor variableTypeId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "9ed945ed-1c5e-4a2a-a094-5d265d301385",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Check returned variable id\", function() {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData[0].id).to.equal(8255);",
+											"    pm.expect(jsonData[1].id).to.equal(8240);",
+											"    pm.expect(jsonData[2].id).to.equal(8250);",
+											"    pm.expect(jsonData[3].id).to.equal(8230);",
+											"    pm.expect(jsonData[4].id).to.equal(8201);",
+											"});",
+											"",
+											"pm.test(\"Check returned variable name\", function() {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData[0].name).to.equal(\"ENTRY_TYPE\");",
+											"    pm.expect(jsonData[1].name).to.equal(\"GID\");",
+											"    pm.expect(jsonData[2].name).to.equal(\"DESIGNATION\");",
+											"    pm.expect(jsonData[3].name).to.equal(\"ENTRY_NO\");",
+											"    pm.expect(jsonData[4].name).to.equal(\"OBS_UNIT_ID\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{study_plot_datasetId}}/variables/{{variableTypeId_germ_desc}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{study_plot_datasetId}}",
+										"variables",
+										"{{variableTypeId_germ_desc}}"
+									]
+								},
+								"description": "GET /crops/{crop}/studies/{studyId}/datasets/{datasetId}/variables/{variableTypeId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered valid inputs and observation units variableTypeId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "9ed945ed-1c5e-4a2a-a094-5d265d301385",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Check returned variable id\", function() {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData[0].id).to.equal(8206);",
+											"});",
+											"",
+											"pm.test(\"Check returned variable name\", function() {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData[0].name).to.equal(\"PLANT_NO\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{study_subobs_datasetId}}/variables/{{variableTypeId_obs_unit}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{study_subobs_datasetId}}",
+										"variables",
+										"{{variableTypeId_obs_unit}}"
+									]
+								},
+								"description": "GET /crops/{crop}/studies/{studyId}/datasets/{datasetId}/variables/{variableTypeId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered non-existing studyId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "9ed945ed-1c5e-4a2a-a094-5d265d301385",
+										"exec": [
+											"pm.test(\"Status code is 404\", function () {",
+											"    pm.response.to.have.status(404);",
+											"});",
+											"pm.test(\"Verify error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors[0].message).to.equal(\"Study does not exist\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{non_existing_study_id}}/datasets/{{study_plot_datasetId}}/variables/{{Trait_cvtermId}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{non_existing_study_id}}",
+										"datasets",
+										"{{study_plot_datasetId}}",
+										"variables",
+										"{{Trait_cvtermId}}"
+									]
+								},
+								"description": "GET /crops/{crop}/studies/{studyId}/datasets/{datasetId}/variables/{variableTypeId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered non-existing datasetId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "9ed945ed-1c5e-4a2a-a094-5d265d301385",
+										"exec": [
+											"pm.test(\"Status code is 404\", function () {",
+											"    pm.response.to.have.status(404);",
+											"});",
+											"pm.test(\"Verify error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors[0].message).to.equal(\"Dataset does not exist\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{non_existing_dataset_id}}/variables/{{Trait_cvtermId}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{non_existing_dataset_id}}",
+										"variables",
+										"{{Trait_cvtermId}}"
+									]
+								},
+								"description": "GET /crops/{crop}/studies/{studyId}/datasets/{datasetId}/variables/{variableTypeId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered string input to studyId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "9ed945ed-1c5e-4a2a-a094-5d265d301385",
+										"exec": [
+											"pm.test(\"Status code is 500\", function () {",
+											"    pm.response.to.have.status(500);",
+											"});",
+											"pm.test(\"Verify error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors[0].message).to.eql(\"For input string: \\\"asd\\\"\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{string_input}}/datasets/{{study_plot_datasetId}}/variables/{{Trait_cvtermId}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{string_input}}",
+										"datasets",
+										"{{study_plot_datasetId}}",
+										"variables",
+										"{{Trait_cvtermId}}"
+									]
+								},
+								"description": "GET /crops/{crop}/studies/{studyId}/datasets/{datasetId}/variables/{variableTypeId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered string input to datasetId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "9ed945ed-1c5e-4a2a-a094-5d265d301385",
+										"exec": [
+											"pm.test(\"Status code is 500\", function () {",
+											"    pm.response.to.have.status(500);",
+											"});",
+											"pm.test(\"Verify error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors[0].message).to.eql(\"For input string: \\\"asd\\\"\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{string_input}}/variables/{{Trait_cvtermId}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{string_input}}",
+										"variables",
+										"{{Trait_cvtermId}}"
+									]
+								},
+								"description": "GET /crops/{crop}/studies/{studyId}/datasets/{datasetId}/variables/{variableTypeId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered string input to variableTypeId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "9ed945ed-1c5e-4a2a-a094-5d265d301385",
+										"exec": [
+											"pm.test(\"Status code is 500\", function () {",
+											"    pm.response.to.have.status(500);",
+											"});",
+											"pm.test(\"Verify error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors[0].message).to.eql(\"For input string: \\\"asd\\\"\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Auth-Token",
+										"type": "text",
+										"value": "{{masterToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{BMSurl}}/crops/{{crop}}/studies/{{studyId}}/datasets/{{study_plot_datasetId}}/variables/{{string_input}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"crops",
+										"{{crop}}",
+										"studies",
+										"{{studyId}}",
+										"datasets",
+										"{{study_plot_datasetId}}",
+										"variables",
+										"{{string_input}}"
+									]
+								},
+								"description": "GET /crops/{crop}/studies/{studyId}/datasets/{datasetId}/variables/{variableTypeId}"
 							},
 							"response": []
 						}


### PR DESCRIPTION
…}/variables/{variableTypeId}
**Call:** GET /crops/{crop}/studies/{studyId}/datasets/{datasetId}/variables/{variableTypeId}

**Scenarios:**

1. Verify response code and body when entered valid inputs and trait variableTypeId
2. Verify response code and body when entered valid inputs and environment detail variableTypeId
3. Verify response code and body when entered valid inputs and experimental design variableTypeId
4. Verify response code and body when entered valid inputs and germplasm descriptor variableTypeId
5. Verify response code and body when entered valid inputs and observation units variableTypeId
6. Verify response code and body when entered non-existing studyId
7. Verify response code and body when entered non-existing datasetId
8. Verify response code and body when entered string input to studyId
9. Verify response code and body when entered string input to datasetId
10. Verify response code and body when entered string input to variableTypeId